### PR TITLE
Update sensor units for WiFi data transit

### DIFF
--- a/custom_components/netgear_wax/sensor.py
+++ b/custom_components/netgear_wax/sensor.py
@@ -5,6 +5,7 @@ from typing import List
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant
 from custom_components.netgear_wax import NetgearDataUpdateCoordinator
+from custom_components.netgear_wax.utils import human_bytes
 
 from .const import (
     DOMAIN, SAFETY_DEVICE_CLASS, DEVICES_ICON, UPDATE_ICON, CHART_DONUT_ICON, ROUTER_NETWORK_ICON, LAN_ICON,
@@ -126,18 +127,21 @@ class NetgearInterfaceTrafficSensor(NetgearSensor):
         NetgearSensor.__init__(self, coordinator, config_entry, sensor_type)
         self._coordinator = coordinator
         self._lan = lan
-        self._attr_unit_of_measurement = "B"
 
     @property
     def state(self):
         stats = self._coordinator.get_stats()
         if self._lan in stats:
-            return self._coordinator.get_stats().get(self._lan).bytes_transferred
+            return human_bytes(self._coordinator.get_stats().get(self._lan).bytes_transferred)
         return 0
 
     @property
     def icon(self) -> str:
         return ROUTER_NETWORK_ICON
+
+    @property
+    def unit_of_measurement(self):
+        return "B"
 
 
 class NetgearAddressSensor(NetgearSensor):


### PR DESCRIPTION
Update the `NetgearInterfaceTrafficSensor` class to use human-readable units for data sizes.

* Import `human_bytes` function from `custom_components.netgear_wax.utils`.
* Modify the `state` property to use the `human_bytes` function for converting bytes to human-readable format.
* Add a `unit_of_measurement` property to return "B".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spencermamer/netgear-wax/pull/1?shareId=907103d6-9e7a-42e0-81df-d5a669c877c7).